### PR TITLE
Nocaptcha nojs fix

### DIFF
--- a/inc/class-wp_recaptcha_nocaptcha.php
+++ b/inc/class-wp_recaptcha_nocaptcha.php
@@ -233,7 +233,7 @@ class WP_reCaptcha_NoCaptcha extends WP_reCaptcha_Captcha {
 													' margin: 10px 25px; padding: 0px; resize: none;" value="">' .
 								'</textarea>' .
 							'</div>' .
-						'</div>';
+						'</div><br>';
 		} else {
 			$return .= __('Please enable JavaScript to submit this form.','wp-recaptcha-integration');
 		}

--- a/inc/class-wp_recaptcha_nocaptcha.php
+++ b/inc/class-wp_recaptcha_nocaptcha.php
@@ -237,7 +237,7 @@ class WP_reCaptcha_NoCaptcha extends WP_reCaptcha_Captcha {
 		} else {
 			$return .= __('Please enable JavaScript to submit this form.','wp-recaptcha-integration');
 		}
-		$return .= '</noscript>';
+		$return .= '<br></noscript>';
 		return $return;
 	}
 	/**

--- a/inc/class-wp_recaptcha_nocaptcha.php
+++ b/inc/class-wp_recaptcha_nocaptcha.php
@@ -215,22 +215,23 @@ class WP_reCaptcha_NoCaptcha extends WP_reCaptcha_Captcha {
 		$return = "<div {$attr_str}></div>";
 		$return .= '<noscript>';
 		if ( WP_reCaptcha::instance()->get_option('recaptcha_noscript') ) {
-			$return .= '<div style="width: 302px; height: 352px;">' .
-							'<div style="width: 302px; height: 352px; position: relative;">' .
-								'<div style="width: 302px; height: 352px; position: absolute;">' .
+			$return .= '<div style="width: 302px; height: 462px;">' .
+							'<div style="width: 302px; height: 422px; position: relative;">' .
+								'<div style="width: 302px; height: 422px; position: absolute;">' .
 									'<iframe src="https://www.google.com/recaptcha/api/fallback?k='.$attr['data-sitekey'].'"' .
 											' frameborder="0" scrolling="no"' .
-											' style="width: 302px; height:352px; border-style: none;">' .
+											' style="width: 302px; height:422px; border-style: none;">' .
 									'</iframe>' .
 								'</div>' .
-								'<div style="width: 250px; height: 80px; position: absolute; border-style: none;' .
-									' bottom: 21px; left: 25px; margin: 0px; padding: 0px; right: 25px;">' .
-									'<textarea id="g-recaptcha-response" name="g-recaptcha-response"' .
-												' class="g-recaptcha-response"' .
-												' style="width: 250px; height: 80px; border: 1px solid #c1c1c1;' .
-														' margin: 0px; padding: 0px; resize: none;" value="">' .
-									'</textarea>' .
-								'</div>' .
+							'</div>' .
+							'<div style="width: 300px; height: 60px; border-style: none;' .
+								' bottom: 12px; left: 25px; margin: 0px; padding: 0px; right: 25px;' .
+								' background: #f9f9f9; border: 1px solid #c1c1c1; border-radius: 3px;">' .
+								'<textarea id="g-recaptcha-response" name="g-recaptcha-response"' .
+											' class="g-recaptcha-response"' .
+											' style="width: 250px; height: 40px; border: 1px solid #c1c1c1;' .
+													' margin: 10px 25px; padding: 0px; resize: none;" value="">' .
+								'</textarea>' .
 							'</div>' .
 						'</div>';
 		} else {


### PR DESCRIPTION
**First** commit fixes the NoCaptcha with JavaScript disabled from being shown as

![image](https://cloud.githubusercontent.com/assets/1855294/9984245/35b6359c-5fe2-11e5-97c0-165850605e65.png)

to

![image](https://cloud.githubusercontent.com/assets/1855294/9984249/3da05620-5fe2-11e5-9055-c3f60a13de21.png)

by using the style options from Google's demo https://www.google.com/recaptcha/api2/demo .

I noticed that besides the styles (especially the height) being a bit off, you also had a misplaced `</div>` in there. In Google's demo there are two closing `div` blocks right after the closing `iframe`, but in your html there is only one closing `div` block in there, when the secon one you close at the very end of the html code, which is what caused the textarea to float like that.

-

The **second** commit fixes

![image](https://cloud.githubusercontent.com/assets/1855294/9984266/5fef9c5e-5fe2-11e5-895e-de77a0dec7d6.png)

to

![image](https://cloud.githubusercontent.com/assets/1855294/9984268/648ada26-5fe2-11e5-8108-a8ff9eda02ff.png)

-

The **third** commit fixes

![image](https://cloud.githubusercontent.com/assets/1855294/9984401/c60049b0-5fe4-11e5-953c-c02f32582840.png)

from running over buttons

![image](https://cloud.githubusercontent.com/assets/1855294/9984414/df47cace-5fe4-11e5-9ae8-781ea4341110.png)

