### PR TITLE
support for password reset protection for older woocommerce versions

### DIFF
--- a/inc/class-wp_recaptcha_woocommerce.php
+++ b/inc/class-wp_recaptcha_woocommerce.php
@@ -70,8 +70,67 @@ class WP_reCaptcha_WooCommerce {
 				if ( $enable_lostpw ) {
 					add_action( 'woocommerce_lostpassword_form' , array($wp_recaptcha,'print_recaptcha_html'),10,0);
 				}
+				if( version_compare( WC()->version , '2.4.0' ) === -1 ){
+					add_filter( 'woocommerce_locate_template', array($this,'locate_template'), 10, 3 );
+
+				}
 			}
 		}
+	}
+	function plugin_path() {
+
+		// gets the absolute path to this plugin directory
+
+		return untrailingslashit( plugin_dir_path( __FILE__ ) );
+
+	}
+
+	function locate_template( $template, $template_name, $template_path ) {
+
+		global $woocommerce;
+
+
+		$_template = $template;
+
+		if ( ! $template_path )
+			$template_path = $woocommerce->template_url;
+
+		$plugin_path = $this->plugin_path() . '/woocommerce/';
+
+
+		// Look within passed path within the theme - this is priority
+
+		$template = locate_template(
+
+			array(
+
+				$template_path . $template_name,
+
+				$template_name
+
+			)
+
+		);
+
+
+		// Modification: Get the template from this plugin, if it exists
+
+		if ( ! $template && file_exists( $plugin_path . $template_name ) )
+
+			$template = $plugin_path . $template_name;
+
+
+		// Use default template
+
+		if ( ! $template )
+
+			$template = $_template;
+
+
+		// Return what we found
+
+		return $template;
+
 	}
 	/*
 	function checkout_fields( $checkout_fields ) {

--- a/inc/woocommerce/myaccount/form-lost-password.php
+++ b/inc/woocommerce/myaccount/form-lost-password.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Lost password form
+ *
+ * @author  WooThemes
+ * @package WooCommerce/Templates
+ * @version 2.3.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+?>
+<?php wc_print_notices(); ?>
+
+<form method="post" class="lost_reset_password">
+
+	<?php if( 'lost_password' == $args['form'] ) : ?>
+
+		<p><?php echo apply_filters( 'woocommerce_lost_password_message', __( 'Lost your password? Please enter your username or email address. You will receive a link to create a new password via email.', 'woocommerce' ) ); ?></p>
+
+		<p class="form-row form-row-first"><label for="user_login"><?php _e( 'Username or email', 'woocommerce' ); ?></label> <input class="input-text" type="text" name="user_login" id="user_login" /></p>
+
+	<?php else : ?>
+
+		<p><?php echo apply_filters( 'woocommerce_reset_password_message', __( 'Enter a new password below.', 'woocommerce') ); ?></p>
+
+		<p class="form-row form-row-first">
+			<label for="password_1"><?php _e( 'New password', 'woocommerce' ); ?> <span class="required">*</span></label>
+			<input type="password" class="input-text" name="password_1" id="password_1" />
+		</p>
+		<p class="form-row form-row-last">
+			<label for="password_2"><?php _e( 'Re-enter new password', 'woocommerce' ); ?> <span class="required">*</span></label>
+			<input type="password" class="input-text" name="password_2" id="password_2" />
+		</p>
+
+		<input type="hidden" name="reset_key" value="<?php echo isset( $args['key'] ) ? $args['key'] : ''; ?>" />
+		<input type="hidden" name="reset_login" value="<?php echo isset( $args['login'] ) ? $args['login'] : ''; ?>" />
+
+	<?php endif; ?>
+
+	<div class="clear"></div>
+	<?php do_action( 'woocommerce_lostpassword_form' ); ?>
+
+	<p class="form-row">
+		<input type="hidden" name="wc_reset_password" value="true" />
+
+		<input type="submit" class="button" value="<?php echo 'lost_password' == $args['form'] ? __( 'Reset Password', 'woocommerce' ) : __( 'Save', 'woocommerce' ); ?>" />
+	</p>
+
+	<?php wp_nonce_field( $args['form'] ); ?>
+
+</form>


### PR DESCRIPTION
Hi,

nice plugin!

I´ve added support for password reset protection for older woocommerce versions. Probably @todo adding admin options to let the user decide if he wants to use included template.
What do you think?
