### PR TITLE
Add missing arg to filter callback

### DIFF
--- a/inc/class-wp_recaptcha.php
+++ b/inc/class-wp_recaptcha.php
@@ -374,7 +374,7 @@ class WP_reCaptcha {
 	 *
 	 *	@return bool false if check does not validate
 	 */
-	function recaptcha_check( ) {
+	function recaptcha_check( $valid=null ) {
 		if ( $this->is_required() )
 			return $this->captcha_instance()->check();
 		return true;


### PR DESCRIPTION
Since recaptcha_check is used as a filter callback it has to accept at
least one argument, apply_filters has to pass one argument; otherwise
warnings are thrown.

As per the documentation, to check a recaptcha response in custom code we have to call

`apply_filters( 'recaptcha_valid' )` - this throws a warning, as filters in WordPress require at least one argument.

`apply_filters( 'recaptcha_valid', false )` - this throws a warning, since the `recaptcha_check` method doesn't expect an argument.
