### PR TITLE
Register Form compatibility with WooCommerce 3.0+

### DIFF
--- a/inc/class-wp_recaptcha_ninjaforms.php
+++ b/inc/class-wp_recaptcha_ninjaforms.php
@@ -124,7 +124,7 @@ class WP_reCaptcha_NinjaForms {
 			// reload recaptcha after failed ajax form submit
 			(function($){
 			$(document).on("submitResponse.default", function(e, response){
-				if ( grecaptcha ) {
+				if ( typeof grecaptcha !== "undefined" ) {
 					var wid = $(\'#ninja_forms_form_\'+response.form_id).find(\'.g-recaptcha\').data(\'widget-id\');
 					grecaptcha.reset(wid);
 				}

--- a/inc/class-wp_recaptcha_woocommerce.php
+++ b/inc/class-wp_recaptcha_woocommerce.php
@@ -58,7 +58,16 @@ class WP_reCaptcha_WooCommerce {
 					add_filter('woocommerce_process_login_errors', array( &$this , 'login_errors' ) , 10 , 3 );
 				}
 				if ( $enable_signup ) {
-					// displaying the captcha at hook 'registration_form' already done by core plugin
+					// Injects recaptcha in Register for WooCommerce >= 3.0
+					// For WooCommerce < 3.0 displaying the captcha at hook 'registration_form' already done by core plugin
+					if ( class_exists( 'WooCommerce' ) ) {
+						global $woocommerce;
+						if ( version_compare( $woocommerce->version, '3.0', ">=" ) ) {
+							add_action('woocommerce_register_form' , array($wp_recaptcha,'print_recaptcha_html'),10,0);
+						}
+					}
+					
+					
 					add_filter('woocommerce_registration_errors', array( &$this , 'login_errors' ) , 10 , 3 );
 // 					if ( ! $enable_order )
 // 						add_filter('woocommerce_checkout_fields', array( &$this , 'checkout_fields' ) , 10 , 3 );


### PR DESCRIPTION
For WooCommerce 3.0+ it is now needed to inject the reCaptcha in the register form.
Based on original solution provided by MrFent37 at https://wordpress.org/support/topic/woocommerce-3-0-registration-error-solved/