### PR TITLE
Fix deprecation check for PHP < 5.4

### DIFF
--- a/wp-recaptcha-integration.php
+++ b/wp-recaptcha-integration.php
@@ -41,17 +41,17 @@ function wp_recaptcha_integration_autoload( $classname ) {
 spl_autoload_register( 'wp_recaptcha_integration_autoload' );
 
 
-// // disable 2.0.0 updates on php < 5.4
-// function wp_recaptcha_disable_updates($value) {
-// 	if ( version_compare(PHP_VERSION, '5.4', '<') ) {
-// 		$plugin_basename = plugin_basename(__FILE__);
-// 		if ( isset( $value->response[ $plugin_basename ] ) && version_compare( $value->response[ $plugin_basename ]['new_version'] , '2.0.0', '>=' ) ) {
-// 			unset( $value->response[ plugin_basename(__FILE__) ] );
-// 		}
-// 	}
-// 	return $value;
-// }
-// add_filter('site_transient_update_plugins', 'wp_recaptcha_disable_updates');
+// disable 2.0.0 updates on php < 5.4
+function wp_recaptcha_disable_updates($value) {
+	if ( version_compare(PHP_VERSION, '5.4', '<') ) {
+		$plugin_basename = plugin_basename(__FILE__);
+		if ( isset( $value->response[ $plugin_basename ] ) && version_compare( $value->response[ $plugin_basename ]->new_version , '2.0.0', '>=' ) ) {
+			unset( $value->response[ plugin_basename(__FILE__) ] );
+		}
+	}
+	return $value;
+}
+add_filter('site_transient_update_plugins', 'wp_recaptcha_disable_updates');
 
 WP_reCaptcha::instance();
 


### PR DESCRIPTION
This function tries to dig into `$value->response[ $plugin_basename ]` as an  array to get the `new_version`, but it's a stdClass!

This commit changes that to property access notation so we don't see `Cannot use object of type stdClass as array`.

I was stuck on v1.2.0 as I couldn't run updates, but now I realise you've commented it out in v1.3.0 so I'm not sure if this fix is needed 🙈 