### PR TITLE
Reset captcha in case of woocommerce checkout error

### DIFF
--- a/inc/class-wp_recaptcha_nocaptcha.php
+++ b/inc/class-wp_recaptcha_nocaptcha.php
@@ -194,6 +194,12 @@ class WP_reCaptcha_NoCaptcha extends WP_reCaptcha_Captcha {
 <?php } ?>
 						});
 						el.setAttribute('data-widget-id',wid);
+						// Add an event listener to reset the captcha in case of woocommerce checkout error
+						if ( typeof jQuery !== 'undefined' )
+							jQuery( document.body ).on('checkout_error', function() {
+								grecaptcha.reset(wid);
+    						});
+
 					} else {
 						wid = el.getAttribute('data-widget-id');
 						grecaptcha.reset(wid);


### PR DESCRIPTION
On the WooCommerce checkout page, if a user validates the reCaptcha but misses a mandatory field, WooCommerce will trigger a checkout error. Problem is: The reCaptcha stays checked but will fails if the order is submitted again.
The only solutions are either to refresh the page (losing the information entered by the user) or wait for the reCaptcha validity to time out.
The proposed change registers an event to reset the object in case of a WC checkout_error event.